### PR TITLE
Add GitHub action for triggering builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: BuildSiteOnSchedule
+on:
+  schedule:
+    - cron: "0 */1 * * *"
+jobs:
+  curl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: curl
+        env:
+          GATSBY_BUILD_WEBHOOK: ${{ secrets.GATSBY_BUILD_WEBHOOK }}
+        uses: wei/curl@master
+        with:
+          args: -X POST "$GATSBY_BUILD_WEBHOOK"


### PR DESCRIPTION
Add a GitHub action to trigger a build on a schedule. Testing with this one before we decide this is a good idea and do the other repos.

## TODO

- [ ] I don't have access to add secrets to your repo. We need `GATSBY_BUILD_WEBHOOK` added to the action secrets.